### PR TITLE
Add ND reordering to permutation_tools

### DIFF
--- a/mesher.py
+++ b/mesher.py
@@ -35,7 +35,7 @@ def main():
     # Check user defined configuration file
 
     if len(sys.argv) == 1:
-        print('ERROR: main.py requires one argument [configuration file] (i.e. main.py Bow)')
+        print('ERROR: mesher.py requires one argument [configuration file] (i.e. mesher.py Bow)')
         return
 
     # Get name of configuration file/module

--- a/permutation_tools.py
+++ b/permutation_tools.py
@@ -16,13 +16,13 @@ def print_usage():
     print('  permutation_tools.py <json_mesh_input_file> [json_mesh_output_file]')
     return
 
-def append_local_cell_id_to_mesh_file(infile,outfile):
+def append_global_cell_id_to_mesh_file(infile,outfile):
     """Read file, find a desired permutation of cell faces, add new permuted ids to json file"""
 
     with open(infile) as f:
         mesh = json.load(f)
 
-    mesh['mesh']['cell_local_id'] = compute_minimum_bandwidth_permutation(mesh['mesh']['neigh'])
+    mesh['mesh']['cell_global_id'] = compute_minimum_bandwidth_permutation(mesh['mesh']['neigh'])
 
     with open(outfile,'w') as f:
         json.dump(mesh, f, indent=4)
@@ -116,4 +116,4 @@ if __name__=="__main__":
     if len(sys.argv) == 3:
         outfile = sys.argv[2]
 
-    append_local_cell_id_to_mesh_file(infile, outfile)
+    append_global_cell_id_to_mesh_file(infile, outfile)

--- a/permutation_tools.py
+++ b/permutation_tools.py
@@ -6,15 +6,22 @@ import numpy as np
 import scipy.sparse as sparse
 import scipy.sparse.csgraph as graph
 
+# Set up CL arguments
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", "--outfile", required=False,
+                help="File for output (default overwrites input file).")
+
+parser.add_argument("-t", "--type", required=False,
+                help="Type of reordering to perform.",
+                nargs='?', const="rcm", type=str, default="rcm")
+
+parser.add_argument("-i", "--infile", required=True,
+                help="File for input.")
+
 import matplotlib as mpl
 mpl.use('AGG')  # non-gui display (much faster)
 import matplotlib.pyplot as plt
-
-
-def print_usage():
-    print('USAGE: ')
-    print('  permutation_tools.py <json_mesh_input_file> [json_mesh_output_file]')
-    return
 
 def append_global_cell_id_to_mesh_file(infile,outfile):
     """Read file, find a desired permutation of cell faces, add new permuted ids to json file"""
@@ -106,14 +113,9 @@ def plot_mat_connectivity(A,filename,**kwargs):
 
 if __name__=="__main__":
 
-    if len(sys.argv) == 1:
-        print_usage()
-        exit(-1)
-
-    infile = sys.argv[1]
-
-    outfile = infile
-    if len(sys.argv) == 3:
-        outfile = sys.argv[2]
+    # Parse the input arguments
+    args = vars(parser.parse_args())
+    if (args["outfile"]==None):
+        args["outfile"] = args["infile"]
 
     append_global_cell_id_to_mesh_file(infile, outfile)

--- a/permutation_tools.py
+++ b/permutation_tools.py
@@ -45,7 +45,7 @@ def compute_rcm_permutation(neighbor_list):
     """Computes the permutation that minimizes the bandwidth of the connectivity matrix
     - uses Reverse CutHill-McKee (RCM) algorithm, which needs CSC or CSR sparse matrix format"""
 
-    A = convert_neighbor_list_to_csr_matrix(neighbor_list)
+    A = convert_neighbor_list_to_compressed_matrix(neighbor_list, sparse.csr_matrix)
 
     # Note we are always dealing with undirected (symmetric) graphs
     permutation = graph.reverse_cuthill_mckee(A,symmetric_mode=True)
@@ -59,8 +59,9 @@ def compute_nd_permutation(neighbor_list):
     pass
 ############################################################################
 
-def convert_neighbor_list_to_csr_matrix(neighbor_list):
-    """Get a scipy.sparse.csr_matrix from a list of neighbors"""
+def convert_neighbor_list_to_compressed_matrix(neighbor_list,compressed_format):
+    """Get a sparse compressed_format from a list of neighbors (assuming aij input)
+    - compressed_format is one of sparse.csr_matrix or sparse.csc_matrix"""
 
     N = len(neighbor_list)
     i = []
@@ -77,7 +78,7 @@ def convert_neighbor_list_to_csr_matrix(neighbor_list):
     val = np.ones(count)
     A = sparse.coo_matrix((val,(i,j)),shape=(N,N))
 
-    return sparse.csr_matrix(A)
+    return compressed_format(A)
 
 
 ## Bandwidth comparison

--- a/permutation_tools.py
+++ b/permutation_tools.py
@@ -23,19 +23,18 @@ import matplotlib as mpl
 mpl.use('AGG')  # non-gui display (much faster)
 import matplotlib.pyplot as plt
 
-def append_global_cell_id_to_mesh_file(infile,outfile):
-    """Read file, find a desired permutation of cell faces, add new permuted ids to json file"""
+def append_global_cell_id_to_mesh_file(args):
+    """Read dictionary of arguments, find a desired permutation of cell faces, add new permuted ids to json file"""
 
-    with open(infile) as f:
+    with open(args["infile"]) as f:
         mesh = json.load(f)
 
     mesh['mesh']['cell_global_id'] = compute_minimum_bandwidth_permutation(mesh['mesh']['neigh'])
 
-    with open(outfile,'w') as f:
+    with open(args["outfile"],'w') as f:
         json.dump(mesh, f, indent=4)
 
     return
-
 
 # permutation functions
 def compute_minimum_bandwidth_permutation(neighbor_list):
@@ -118,4 +117,4 @@ if __name__=="__main__":
     if (args["outfile"]==None):
         args["outfile"] = args["infile"]
 
-    append_global_cell_id_to_mesh_file(infile, outfile)
+    append_global_cell_id_to_mesh_file(args)


### PR DESCRIPTION
- Now uses argparse (different calling syntax than before, running the script with no args produces an error and prints usage)
- Nested dissection ordering added as a second reordering option (default is still RCM)
- misc clarifications of names and generalizations of conversion functions